### PR TITLE
Correct type declaration (fixes -Werror)

### DIFF
--- a/src/sedml.cpp
+++ b/src/sedml.cpp
@@ -321,7 +321,7 @@ public:
             }
             else
             {
-                for (int vc=0; vc < dg->getNumVariables(); ++vc)
+                for (unsigned int vc=0; vc < dg->getNumVariables(); ++vc)
                 {
                     SedVariable* v = dg->getVariable(vc);
                     MyVariable var;
@@ -335,7 +335,7 @@ public:
                     d.variables[v->getId()] = var;
                 }
             }
-            for (int pc=0; pc < dg->getNumParameters(); ++pc)
+            for (unsigned int pc=0; pc < dg->getNumParameters(); ++pc)
             {
                 SedParameter* p = dg->getParameter(pc);
                 std::cout << "\t\tParameter " << p->getId()


### PR DESCRIPTION
- They are declared like so in `sedml/SedDataGenerator.cpp`

    ```
    unsigned int
    SedDataGenerator::getNumParameters() const

    unsigned int
    SedDataGenerator::getNumVariables() const
    ```


Otherwise the following happens:

```
FAILED: /usr/bin/c++   -DCELLML_STATIC -DLIBXML_STATIC -DLIBXML_XPATH_ENABLED -I/home/build/work/GET_ROOT/build/GET/get-simulator/src -I. -I/home/build/work/GET_ROOT/include -I/home/build/work/GET_ROOT/include/cellml -I/home/build/work/GET_ROOT/include/libxml2 -O3 -DNDEBUG -fPIE   -std=c++11 -Wall -Werror -MD -MT CMakeFiles/get-sed-ml-client.dir/src/sedml.cpp.o -MF CMakeFiles/get-sed-ml-client.dir/src/sedml.cpp.o.d -o CMakeFiles/get-sed-ml-client.dir/src/sedml.cpp.o -c /home/build/work/GET_ROOT/build/GET/get-simulator/src/sedml.cpp
/home/build/work/GET_ROOT/build/GET/get-simulator/src/sedml.cpp: In member function ‘int MyReport::resolveDataSets(libsedml::SedDocument*)’:
/home/build/work/GET_ROOT/build/GET/get-simulator/src/sedml.cpp:324:57: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
                 for (int vc=0; vc < dg->getNumVariables(); ++vc)
                                                         ^
/home/build/work/GET_ROOT/build/GET/get-simulator/src/sedml.cpp:338:54: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
             for (int pc=0; pc < dg->getNumParameters(); ++pc)
                                                      ^
cc1plus: all warnings being treated as errors
```